### PR TITLE
Publicizer interface members fix

### DIFF
--- a/AssemblyLib/Remapper/Publicizer.cs
+++ b/AssemblyLib/Remapper/Publicizer.cs
@@ -42,6 +42,11 @@ internal sealed class Publicizer(Statistics stats)
             Logger.Log($"Publicizing Property [{property.DeclaringType}::{property.Name}]", 
                 diskOnly: true);
 
+            // TODO: This is hacky but works for now, find a better solution. Need to check MD tokens to build associations,
+            // this is a problem for later me.
+            
+            // NOTE: Ignore properties that are interface impls that are private.
+            // This causes issues with json deserialization in the server.
             if (property.Name?.Contains(".") ?? false) continue;
             
             if (property.GetMethod != null) PublicizeMethod(property.GetMethod);
@@ -59,9 +64,7 @@ internal sealed class Publicizer(Statistics stats)
         
         // Workaround to not publicize a specific method so the game doesn't crash
         if (method.Name == "TryGetScreen") return;
-
-        if (method.Name?.Contains(".") ?? false) return;
-
+        
         method.Attributes &= ~MethodAttributes.MemberAccessMask;
         method.Attributes |= MethodAttributes.Public;
 
@@ -85,8 +88,6 @@ internal sealed class Publicizer(Statistics stats)
         foreach (var field in type.Fields)
         {
             if (field.IsPublic || IsEventField(type, field)) continue;
-            
-            if (field.Name?.Contains(".") ?? false) continue;
             
             Logger.Log($"Publicizing Field [{field.DeclaringType}::{field.Name}]", 
                 diskOnly: true);

--- a/AssemblyLib/Remapper/Publicizer.cs
+++ b/AssemblyLib/Remapper/Publicizer.cs
@@ -41,6 +41,8 @@ internal sealed class Publicizer(Statistics stats)
         {
             Logger.Log($"Publicizing Property [{property.DeclaringType}::{property.Name}]", 
                 diskOnly: true);
+
+            if (property.Name?.Contains(".") ?? false) continue;
             
             if (property.GetMethod != null) PublicizeMethod(property.GetMethod);
             if (property.SetMethod != null) PublicizeMethod(property.SetMethod);
@@ -57,6 +59,8 @@ internal sealed class Publicizer(Statistics stats)
         
         // Workaround to not publicize a specific method so the game doesn't crash
         if (method.Name == "TryGetScreen") return;
+
+        if (method.Name?.Contains(".") ?? false) return;
 
         method.Attributes &= ~MethodAttributes.MemberAccessMask;
         method.Attributes |= MethodAttributes.Public;
@@ -81,6 +85,8 @@ internal sealed class Publicizer(Statistics stats)
         foreach (var field in type.Fields)
         {
             if (field.IsPublic || IsEventField(type, field)) continue;
+            
+            if (field.Name?.Contains(".") ?? false) continue;
             
             Logger.Log($"Publicizing Field [{field.DeclaringType}::{field.Name}]", 
                 diskOnly: true);


### PR DESCRIPTION
Fix interface inherited properties getting publicized, this causes JSON de-serialization issues in the server. Temp fix, find better solution later. 